### PR TITLE
add Tier = "Private" to all private subnets

### DIFF
--- a/subnets.tf
+++ b/subnets.tf
@@ -8,6 +8,7 @@ resource "aws_subnet" "public_a" {
   availability_zone = "${var.region}a"
   tags = {
     Name = "${var.vpc_name}-public-a"
+    Tier = "Public"
   }
 }
 
@@ -17,6 +18,7 @@ resource "aws_subnet" "public_b" {
   availability_zone = "${var.region}b"
   tags = {
     Name = "${var.vpc_name}-public-b"
+    Tier = "Public"
   }
 }
 
@@ -26,6 +28,7 @@ resource "aws_subnet" "public_c" {
   availability_zone = "${var.region}c"
   tags = {
     Name = "${var.vpc_name}-public-c"
+    Tier = "Public"
   }
 }
 

--- a/subnets.tf
+++ b/subnets.tf
@@ -39,6 +39,7 @@ resource "aws_subnet" "private_a" {
   availability_zone = "${var.region}a"
   tags = {
     Name = "${var.vpc_name}-private-a"
+    Tier = "Private"
   }
 }
 
@@ -48,6 +49,7 @@ resource "aws_subnet" "private_b" {
   availability_zone = "${var.region}b"
   tags = {
     Name = "${var.vpc_name}-private-b"
+    Tier = "Private"
   }
 }
 
@@ -57,5 +59,6 @@ resource "aws_subnet" "private_c" {
   availability_zone = "${var.region}c"
   tags = {
     Name = "${var.vpc_name}-private-c"
+    Tier = "Private"
   }
 }


### PR DESCRIPTION
# Purpose
Our TF code has a lot of lookups that look like
```
data "aws_subnet_ids" "private" {
  vpc_id = data.aws_vpc.selected.id

  tags = {
    Tier = "Private"
  }
}
```
but this module doesn't actually tag the private subnets (must have been manually tagged or something).  This PR just adds tags to the private subnets
# Implementation
Minor change to add the `Tier = "Private"` tag to private subnets
