### PR TITLE
Drop VPN Routing Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ module "aws_ha_vpc" {
   
   vpc_name = "test"
   vpc_cidr = "10.0.0.0/16"
-  vpn_internal_cidr = "10.100.0.0/20"
-
   
   public_subnet_a_cidr  = "10.0.10.0/24"
   public_subnet_b_cidr  = "10.0.11.0/24"
@@ -26,7 +24,6 @@ module "aws_ha_vpc" {
 
 - `vpc_cidr` - the cidr notated ip space of the vpc.
 - `vpc_name` - the name of the vpc. 
-- `vpn_internal_cidr` - the local network CIDR for VPN use.
 - `public_subnet_a_cidr` - cidr for public subnet a
 - `public_subnet_b_cidr` - cidr for public subnet b
 - `public_subnet_c_cidr` - cidr for public subnet c

--- a/routes.tf
+++ b/routes.tf
@@ -17,13 +17,6 @@ resource "aws_route" "public_igw" {
   depends_on                = ["aws_route_table.public"]
 }
 
-resource "aws_route" "vpn_gw_public" {
-  route_table_id            = "${aws_route_table.public.id}"
-  destination_cidr_block    = "${var.vpn_internal_cidr}"
-  gateway_id                = "${aws_vpn_gateway.vpn_gw.id}"
-  depends_on                = ["aws_route_table.public"]
-}
-
 /* 
   Private Routes 
 */
@@ -43,13 +36,6 @@ resource "aws_route" "private_igw_a" {
   depends_on                = ["aws_route_table.private_a"]
 }
 
-resource "aws_route" "vpn_gw_private_a" {
-  route_table_id            = "${aws_route_table.private_a.id}"
-  destination_cidr_block    = "${var.vpn_internal_cidr}"
-  gateway_id                = "${aws_vpn_gateway.vpn_gw.id}"
-  depends_on                = ["aws_route_table.private_a"]
-}
-
 resource "aws_route_table" "private_b" {
   vpc_id = "${aws_vpc.main.id}"
 
@@ -65,13 +51,6 @@ resource "aws_route" "private_igw_b" {
   depends_on                = ["aws_route_table.private_b"]
 }
 
-resource "aws_route" "vpn_gw_private_b" {
-  route_table_id            = "${aws_route_table.private_b.id}"
-  destination_cidr_block    = "${var.vpn_internal_cidr}"
-  gateway_id                = "${aws_vpn_gateway.vpn_gw.id}"
-  depends_on                = ["aws_route_table.private_b"]
-}
-
 resource "aws_route_table" "private_c" {
   vpc_id = "${aws_vpc.main.id}"
 
@@ -84,12 +63,5 @@ resource "aws_route" "private_igw_c" {
   route_table_id            = "${aws_route_table.private_c.id}"
   destination_cidr_block    = "0.0.0.0/0"
   nat_gateway_id            = "${aws_nat_gateway.private_gw_c.id}"
-  depends_on                = ["aws_route_table.private_c"]
-}
-
-resource "aws_route" "vpn_gw_private_c" {
-  route_table_id            = "${aws_route_table.private_c.id}"
-  destination_cidr_block    = "${var.vpn_internal_cidr}"
-  gateway_id                = "${aws_vpn_gateway.vpn_gw.id}"
   depends_on                = ["aws_route_table.private_c"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,3 @@
-variable "vpn_internal_cidr" {
-}
 variable "vpc_cidr" {
   default = "10.0.0.0/16"
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -7,14 +7,3 @@ resource "aws_vpc" "main" {
     Name = "${var.vpc_name}"
   }
 }
-
-resource "aws_vpn_gateway" "vpn_gw" {
-  tags = {
-    Name = "${var.vpc_name}-vpn-gateway"
-  }
-}
-
-resource "aws_vpn_gateway_attachment" "vpn_attachment" {
-  vpc_id         = "${aws_vpc.main.id}"
-  vpn_gateway_id = "${aws_vpn_gateway.vpn_gw.id}"
-}


### PR DESCRIPTION
# Purpose
Tear-down the office VPN

# Implementation
* Update this legacy vpc module to drop all of the VPN gateway/routing config
* Push a new 0.6.0 tag for these changes
* Update all usages of this module in guru-ops to point to the new 0.6.0 tag (separate guru-ops PR: https://github.com/guruhq/guru-ops/pull/884)

# Reviewers
@shawncatz 