### PR TITLE
Refactor to support arbitrary subnet counts

### DIFF
--- a/moves.tf
+++ b/moves.tf
@@ -1,0 +1,119 @@
+moved {
+  from = aws_eip.private_gw_a
+  to   = aws_eip.private_gw[0]
+}
+
+moved {
+  from = aws_eip.private_gw_b
+  to   = aws_eip.private_gw[1]
+}
+
+moved {
+  from = aws_eip.private_gw_c
+  to   = aws_eip.private_gw[2]
+}
+
+moved {
+  from = aws_nat_gateway.private_gw_a
+  to   = aws_nat_gateway.private_gw[0]
+}
+
+moved {
+  from = aws_nat_gateway.private_gw_b
+  to   = aws_nat_gateway.private_gw[1]
+}
+
+moved {
+  from = aws_nat_gateway.private_gw_c
+  to   = aws_nat_gateway.private_gw[2]
+}
+
+moved {
+  from = aws_route_table_association.public_a
+  to   = aws_route_table_association.public[0]
+}
+
+moved {
+  from = aws_route_table_association.public_b
+  to   = aws_route_table_association.public[1]
+}
+
+moved {
+  from = aws_route_table_association.public_c
+  to   = aws_route_table_association.public[2]
+}
+
+moved {
+  from = aws_route_table_association.private_a
+  to   = aws_route_table_association.private[0]
+}
+
+moved {
+  from = aws_route_table_association.private_b
+  to   = aws_route_table_association.private[1]
+}
+
+moved {
+  from = aws_route_table_association.private_c
+  to   = aws_route_table_association.private[2]
+}
+
+moved {
+  from = aws_route_table.private_a
+  to   = aws_route_table.private[0]
+}
+
+moved {
+  from = aws_route_table.private_b
+  to   = aws_route_table.private[1]
+}
+
+moved {
+  from = aws_route_table.private_c
+  to   = aws_route_table.private[2]
+}
+
+moved {
+  from = aws_route.private_igw_a
+  to   = aws_route.private_igw[0]
+}
+
+moved {
+  from = aws_route.private_igw_b
+  to   = aws_route.private_igw[1]
+}
+
+moved {
+  from = aws_route.private_igw_c
+  to   = aws_route.private_igw[2]
+}
+
+moved {
+  from = aws_subnet.public_a
+  to   = aws_subnet.public[0]
+}
+
+moved {
+  from = aws_subnet.public_b
+  to   = aws_subnet.public[1]
+}
+
+moved {
+  from = aws_subnet.public_c
+  to   = aws_subnet.public[2]
+}
+
+moved {
+  from = aws_subnet.private_a
+  to   = aws_subnet.private[0]
+}
+
+moved {
+  from = aws_subnet.private_b
+  to   = aws_subnet.private[1]
+}
+
+moved {
+  from = aws_subnet.private_c
+  to   = aws_subnet.private[2]
+}

--- a/nat_gateways.tf
+++ b/nat_gateways.tf
@@ -1,26 +1,10 @@
-resource "aws_eip" "private_gw_a" {
-  vpc = true
+resource "aws_eip" "private_gw" {
+  count = length(var.private_cidrs)
+  vpc   = true
 }
 
-resource "aws_eip" "private_gw_b" {
-  vpc = true
-}
-
-resource "aws_eip" "private_gw_c" {
-  vpc = true
-}
-
-resource "aws_nat_gateway" "private_gw_a" {
-  allocation_id = aws_eip.private_gw_a.id
-  subnet_id     = aws_subnet.public_a.id
-}
-
-resource "aws_nat_gateway" "private_gw_b" {
-  allocation_id = aws_eip.private_gw_b.id
-  subnet_id     = aws_subnet.public_b.id
-}
-
-resource "aws_nat_gateway" "private_gw_c" {
-  allocation_id = aws_eip.private_gw_c.id
-  subnet_id     = aws_subnet.public_c.id
+resource "aws_nat_gateway" "private_gw" {
+  count         = length(var.private_cidrs)
+  allocation_id = aws_eip.private_gw[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,16 +2,8 @@ output "vpc_id" {
   value = aws_vpc.main.id
 }
 
-output "private_route_a_id" {
-  value = aws_route_table.private_a.id
-}
-
-output "private_route_b_id" {
-  value = aws_route_table.private_b.id
-}
-
-output "private_route_c_id" {
-  value = aws_route_table.private_c.id
+output "private_routes" {
+  value = [for table in aws_route_table.private : table.id]
 }
 
 output "public_route_id" {

--- a/route_table_associations.tf
+++ b/route_table_associations.tf
@@ -1,37 +1,11 @@
-/*
-  Public Route Associations
-*/
-
-resource "aws_route_table_association" "public_a" {
-  subnet_id      = aws_subnet.public_a.id
+resource "aws_route_table_association" "public" {
+  count          = length(var.public_cidrs)
+  subnet_id      = aws_subnet.public[count.index].id
   route_table_id = aws_route_table.public.id
 }
 
-resource "aws_route_table_association" "public_b" {
-  subnet_id      = aws_subnet.public_b.id
-  route_table_id = aws_route_table.public.id
-}
-
-resource "aws_route_table_association" "public_c" {
-  subnet_id      = aws_subnet.public_c.id
-  route_table_id = aws_route_table.public.id
-}
-
-/*
-  Private Route Associations
-*/
-
-resource "aws_route_table_association" "private_a" {
-  subnet_id      = aws_subnet.private_a.id
-  route_table_id = aws_route_table.private_a.id
-}
-
-resource "aws_route_table_association" "private_b" {
-  subnet_id      = aws_subnet.private_b.id
-  route_table_id = aws_route_table.private_b.id
-}
-
-resource "aws_route_table_association" "private_c" {
-  subnet_id      = aws_subnet.private_c.id
-  route_table_id = aws_route_table.private_c.id
+resource "aws_route_table_association" "private" {
+  count          = length(var.private_cidrs)
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
 }

--- a/routes.tf
+++ b/routes.tf
@@ -1,7 +1,3 @@
-/*
-  Public Route
-*/
-
 resource "aws_route_table" "public" {
   vpc_id = aws_vpc.main.id
 
@@ -17,51 +13,19 @@ resource "aws_route" "public_igw" {
   depends_on             = [aws_route_table.public]
 }
 
-/*
-  Private Routes
-*/
-
-resource "aws_route_table" "private_a" {
+resource "aws_route_table" "private" {
+  count  = length(var.private_cidrs)
   vpc_id = aws_vpc.main.id
 
   tags = {
-    Name = "Private Route AZ A"
+    Name = var.private_route_names[count.index]
   }
 }
 
-resource "aws_route" "private_igw_a" {
-  route_table_id         = aws_route_table.private_a.id
+resource "aws_route" "private_igw" {
+  count                  = length(var.private_cidrs)
+  route_table_id         = aws_route_table.private[count.index].id
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.private_gw_a.id
-  depends_on             = [aws_route_table.private_a]
-}
-
-resource "aws_route_table" "private_b" {
-  vpc_id = aws_vpc.main.id
-
-  tags = {
-    Name = "Private Route AZ B"
-  }
-}
-
-resource "aws_route" "private_igw_b" {
-  route_table_id         = aws_route_table.private_b.id
-  destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.private_gw_b.id
-  depends_on             = [aws_route_table.private_b]
-}
-
-resource "aws_route_table" "private_c" {
-  vpc_id = aws_vpc.main.id
-
-  tags = {
-    Name = "Private Route AZ C"
-  }
-}
-
-resource "aws_route" "private_igw_c" {
-  route_table_id         = aws_route_table.private_c.id
-  destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.private_gw_c.id
-  depends_on             = [aws_route_table.private_c]
+  nat_gateway_id         = aws_nat_gateway.private_gw[count.index].id
+  depends_on             = [aws_route_table.private]
 }

--- a/subnets.tf
+++ b/subnets.tf
@@ -1,69 +1,27 @@
 data "aws_region" "current" {}
 
-/*
-  Public Subnets
-*/
+data "aws_availability_zones" "available" {
+  state = "available"
+}
 
-resource "aws_subnet" "public_a" {
+resource "aws_subnet" "public" {
+  count             = length(var.public_cidrs)
   vpc_id            = aws_vpc.main.id
-  cidr_block        = var.public_subnet_a_cidr
-  availability_zone = "${data.aws_region.current.name}a"
+  cidr_block        = var.public_cidrs[count.index]
+  availability_zone = data.aws_availability_zones.available.names[count.index]
   tags = merge(var.public_subnet_tags, {
-    Name = "${var.vpc_name}-public-a"
+    Name = "${var.vpc_name}-${var.public_subnet_names[count.index]}"
     Tier = "Public"
   })
 }
 
-resource "aws_subnet" "public_b" {
+resource "aws_subnet" "private" {
+  count             = length(var.private_cidrs)
   vpc_id            = aws_vpc.main.id
-  cidr_block        = var.public_subnet_b_cidr
-  availability_zone = "${data.aws_region.current.name}b"
-  tags = merge(var.public_subnet_tags, {
-    Name = "${var.vpc_name}-public-b"
-    Tier = "Public"
-  })
-}
-
-resource "aws_subnet" "public_c" {
-  vpc_id            = aws_vpc.main.id
-  cidr_block        = var.public_subnet_c_cidr
-  availability_zone = "${data.aws_region.current.name}c"
-  tags = merge(var.public_subnet_tags, {
-    Name = "${var.vpc_name}-public-c"
-    Tier = "Public"
-  })
-}
-
-/*
-  Private Subnets
-*/
-
-resource "aws_subnet" "private_a" {
-  vpc_id            = aws_vpc.main.id
-  cidr_block        = var.private_subnet_a_cidr
-  availability_zone = "${data.aws_region.current.name}a"
+  cidr_block        = var.private_cidrs[count.index]
+  availability_zone = data.aws_availability_zones.available.names[count.index]
   tags = merge(var.private_subnet_tags, {
-    Name = "${var.vpc_name}-private-a"
-    Tier = "Private"
-  })
-}
-
-resource "aws_subnet" "private_b" {
-  vpc_id            = aws_vpc.main.id
-  cidr_block        = var.private_subnet_b_cidr
-  availability_zone = "${data.aws_region.current.name}b"
-  tags = merge(var.private_subnet_tags, {
-    Name = "${var.vpc_name}-private-b"
-    Tier = "Private"
-  })
-}
-
-resource "aws_subnet" "private_c" {
-  vpc_id            = aws_vpc.main.id
-  cidr_block        = var.private_subnet_c_cidr
-  availability_zone = "${data.aws_region.current.name}c"
-  tags = merge(var.private_subnet_tags, {
-    Name = "${var.vpc_name}-private-c"
+    Name = "${var.vpc_name}-${var.private_subnet_names[count.index]}"
     Tier = "Private"
   })
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,25 @@
 variable "vpc_cidr" {
-  default = "10.0.0.0/16"
 }
 
 variable "vpc_name" {
-  default = "test_name"
+}
+
+variable "public_cidrs" {
+}
+
+variable "public_subnet_names" {
+  default = ["public-a", "public-b", "public-c"]
+}
+
+variable "private_cidrs" {
+}
+
+variable "private_subnet_names" {
+  default = ["private-a", "private-b", "private-c"]
+}
+
+variable "private_route_names" {
+  default = ["Private Route AZ A", "Private Route AZ B", "Private Route AZ C"]
 }
 
 variable "enable_dns_hostnames" {
@@ -12,28 +28,6 @@ variable "enable_dns_hostnames" {
 
 variable "enable_dns_support" {
   default = "true"
-}
-
-variable "public_subnet_a_cidr" {
-  default = "10.0.1.0/24"
-}
-
-variable "public_subnet_b_cidr" {
-  default = "10.0.2.0/24"
-}
-
-variable "public_subnet_c_cidr" {
-  default = "10.0.3.0/24"
-}
-
-variable "private_subnet_a_cidr" {
-  default = "10.0.4.0/24"
-}
-variable "private_subnet_b_cidr" {
-  default = "10.0.5.0/24"
-}
-variable "private_subnet_c_cidr" {
-  default = "10.0.6.0/24"
 }
 
 variable "private_subnet_tags" {


### PR DESCRIPTION
# Purpose
Refactor to an interface that will work for our other prod VPC stacks so we can dedupe those.

Also, closer match our newer `aws/vpc` module interface so that we can eventually switch all of our stacks from this module to that newer module.

# Implementation
* Eliminate the 3 public, 3 private subnet assumption. Instead support an arbitrary number of public and private subnets as input vars.
  - This is necessary for some of the prod VPCs that _don't_ have 3 public+private subnets
* Add a bunch of `moved` blocks so that the refactor is transparent to all of the stacks that consume the module.

# Notifications
@shawncatz 