### PR TITLE
Drop deprecated vpc attr from eip resource

### DIFF
--- a/nat_gateways.tf
+++ b/nat_gateways.tf
@@ -1,6 +1,5 @@
 resource "aws_eip" "private_gw" {
   count = length(var.private_cidrs)
-  vpc   = true
 }
 
 resource "aws_nat_gateway" "private_gw" {


### PR DESCRIPTION
# Purpose
Fix/address provider warning for AWS 5.x provider.

# Implementation
Drop the deprecated `vpc` attr from the `aws_eip` resource. This was used to differentiate between "EC2 classic" and modern VPCs. The EC2 classic stuff is no longer supported on AWS and the provider now warns about this attr being dropped in the future to match.

# Notifications
@jplater-guru @petemichel77 @jahlbornG 